### PR TITLE
Improve release-schedule.md so that it displays properly in the website

### DIFF
--- a/source/community/release-schedule.md
+++ b/source/community/release-schedule.md
@@ -8,7 +8,9 @@ Generally there are 3 active versions of glusterfs. The minor release of those v
 This is the tentative release schedule for glusterfs.
 
   * **10th of every month:** A minor release of the glusterfs-3.5 version
+  * 
   * **20th of every month:** A minor release of the glusterfs-3.6 version
+  * 
   * **30th of every month:** A minor release of the glusterfs-3.7 version
 
 The dates are tentative and below you can see the next immediate release that is going to happen and its data.


### PR DESCRIPTION
As of now, the time table of release of different versions of gluster are shown in the same line instead of each release being displayed in different separate lines.

This change fixes that issue.
