### PR TITLE
Use https url for fetching google fonts

### DIFF
--- a/source/stylesheets/fonts/fonts.css
+++ b/source/stylesheets/fonts/fonts.css
@@ -1,3 +1,3 @@
 /* Place your font info and files here */
-@import url(http://fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700,700italic,900,900italic);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700,700italic,900,900italic);
 


### PR DESCRIPTION
fixes Chrome warnings about loading unsafe scripts.
