### PR TITLE
Adding gluster test matrix to the gluster website

### DIFF
--- a/source/community/gluster_test_matrix.html
+++ b/source/community/gluster_test_matrix.html
@@ -1,0 +1,276 @@
+<html>
+<head>
+<title> Gluster Test Matrix </title>
+</head>
+<body>
+<h1>
+    Gluster Test Matrix
+</h1>
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<p>
+<h2> Smoke Tests </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">Source Build<br></th>
+    <th class="tg-yw4l">Yes<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">Posix Compliance<br></td>
+    <td class="tg-yw4l">Yes</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">dbench</td>
+    <td class="tg-yw4l">Yes</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Functional Tests </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-031e">tests/basic<br></th>
+    <th class="tg-031e">Yes</th>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Regression Tests </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-031e">tests/bugs<br></th>
+    <th class="tg-031e">Yes</th>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Performance Tests </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-031e">tests/performance<br></th>
+    <th class="tg-031e">No</th>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Static Code Analysis Tests </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">Coverity<br></th>
+    <th class="tg-yw4l">Yes<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">SonarQube<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">clang</td>
+    <td class="tg-yw4l">In Progress</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - Brick file systems</h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">xfs<br></th>
+    <th class="tg-yw4l">Yes<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">ext4<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">btrfs</td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">zfs</td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - Access Protocols</h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">smb<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">nfs<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">swift</td>
+    <td class="tg-yw4l">Yes</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - Transport Protocols </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">rdma<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">socket-ipv6<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - libgfapi bidnings</h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">python<br></th>
+    <th class="tg-yw4l">Yes<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">java<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">go</td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">ruby</td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - Tools </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">gdeploy<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">heketi<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - OS environments </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">firewalld<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">ufw<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">selinux<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">apparmor<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">sysvinit<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">systemd<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Integration - Consumers/Cloud environments </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">qemu<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">openstack/cinder<br></td>
+    <td class="tg-yw4l">Yes</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">openstack/manila<br></td>
+    <td class="tg-yw4l">Yes</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">openshift/docker/container<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">aws<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">azure<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">hadoop<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Upgrade Tests</h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">Major version upgrades<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">Minor version upgrades<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Longevity</h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">Memory leaks<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">Log accumulation<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Distro Packaging </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">rpm<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">debian<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+<p>
+<h2> Documentation Checks </h2>
+<table class="tg">
+  <tr>
+    <th class="tg-yw4l">Release Notes<br></th>
+    <th class="tg-yw4l">No<br></th>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">Admin Guide<br></td>
+    <td class="tg-yw4l">No</td>
+  </tr>
+</table>
+</p>
+</body>
+</html>


### PR DESCRIPTION
This patch adds the missing gluster test matrix for the gluster website. This patch is a plain html file with test matrix table and does not contain any CSS stuff.

Signed-off-by: M S Vishwanath Bhat msvbhat@gmail.com
