### PR TITLE
Adding Gluster.org Blog

### DIFF
--- a/source/layouts/_navbar_static_top.haml
+++ b/source/layouts/_navbar_static_top.haml
@@ -28,8 +28,8 @@
             %span.caret
           %ul.dropdown-menu( role="menu" )
             %li
-              %a{ :href=>"/news" }
-                Gluster News and Announcements
+              %a{ :href=>"http://blog.gluster.org" }
+                Gluster.org Blog
             %li
               %a{ :href=>"http://planet.gluster.org" }
                 Planet Gluster - News and blog posts related to storage and gluster


### PR DESCRIPTION
Removing 'news' and adding the blog, which is better maintained.
