### PR TITLE
Refocus "Converged HA" to "External Management"

### DIFF
--- a/source/community/roadmap/3.8/index.md
+++ b/source/community/roadmap/3.8/index.md
@@ -1079,18 +1079,17 @@ both when Linux is used as a client and as a server.
 
 # At Risk
 
-### Converged HA for NFS-Ganesha and Samba
-Integration with [Storhaug], a Pacemaker-based HA solution for clustered
-storage platforms.
+### Integrate with external resource management software
+Gluster should have an operating mode whereby it does not do any management or configuration of external services like NFS-Ganesha or Samba. This is to facilitate integration with things like [storhaug], a Pacemaker-based HA solution for clustered storage platforms.
 
 * **Status**:
-  (13-March-2016) New upstream project, needs integration, packaging and testing.
+  New proposal
 
 * **Owners**:
   Kaleb Keithley, Jose Rivera
 
 * **Feature Page**:
-  ...
+  * [Feature page on GitHub](https://github.com/jarrpa/glusterfs-specs/blob/patch-1/under_review/external_management.md)
 
 * **Tracker Bug and Patches**:
   ...
@@ -1112,6 +1111,7 @@ storage platforms.
 
 * **Advertisement**
   *(link to emails in gluster-devel archive with blog and video)*
+
 
 ### Tiering Performance Enhancements
 **TODO**: this should probably be split in multiple features? (2) and (3) are


### PR DESCRIPTION
There's not real work that need to be done to integrate GlusterFS with pacemaker and storhaug. However, it would be convenient to have a simple way to make sure GlusterFS is operating with a particular set of features disabled.
