### PR TITLE
release-schedule: update to include version 3.8

### DIFF
--- a/source/community/release-schedule.md
+++ b/source/community/release-schedule.md
@@ -6,10 +6,9 @@ title: Release Schedule
 
 Generally there are 3 active versions of GlusterFS. A minor release of each of these
 versions is generally scheduled every month. As of now the active versions of
-GlusterFS are GlusterFS-3.5, GlusterFS-3.6 and GlusterFS-3.7.
+GlusterFS are GlusterFS-3.6, GlusterFS-3.7 and GlusterFS-3.8.
 This is the tentative release schedule for GlusterFS:
 
-  * **10th of every month:** A minor release of the GlusterFS-3.5 version
+  * **10th of every month:** A minor release of the GlusterFS-3.8 version
   * **20th of every month:** A minor release of the GlusterFS-3.6 version
   * **30th of every month:** A minor release of the GlusterFS-3.7 version
-


### PR DESCRIPTION
When we release 3.8, 3.5 got EOL. The new version takes the update schedule for
the deprecated one.

Signed-off-by: Niels de Vos ndevos@redhat.com
