### PR TITLE
Update getting involved page with github references

### DIFF
--- a/source/community/index.html.haml
+++ b/source/community/index.html.haml
@@ -47,6 +47,14 @@ navigation: community
       &mdash; check out what's happening around GlusterFS!
 
     %h4 
+      =link_to "New Features and Improvements", "https://github.com/gluster/glusterfs/issues"
+    %p
+      Gluster uses github issues for new feature requests and improvement suggestions.
+      Open
+      =link_to "a github issue", "https://github.com/gluster/glusterfs/issues/new"
+      for any requests that you may have.
+
+    %h4 
       =link_to "Bug Tracking", "https://bugzilla.redhat.com/enter_bug.cgi?classification=Community"
     %p
       Gluster uses the Red Hat Bugzilla for development and bug tracking. 
@@ -55,7 +63,7 @@ navigation: community
       section.
     %dl
       %dt=link_to "&raquo; Report a problem in Gluster", "https://bugzilla.redhat.com/enter_bug.cgi?product=GlusterFS"
-      %dt=link_to "&raquo; Report a problem in Documentation", "https://bugzilla.redhat.com/enter_bug.cgi?product=Gluster-Documentation"
+      %dt=link_to "&raquo; Report a problem in Documentation", "https://github.com/gluster/glusterdocs/issues/new"
 
 
 


### PR DESCRIPTION
Documentation issues can be filed at github (makes it easier to work with than bugzilla).

Further, segregating bugs and feature requests to bugzilla and github accordingly.