### PR TITLE
Update release-schedule to reflect 4.0 as STM

### DIFF
--- a/source/community/release-schedule.md
+++ b/source/community/release-schedule.md
@@ -34,4 +34,4 @@ A minor update release for each maintaned version is generally scheduled monthly
 | 3.10     | LTM             | 2017-02-27      | 30th            | 4.0         |            |
 | **3.11** | **STM**         | **2017-05-30**  | **20th**        | **3.12**    |            |
 | *3.12*   | *Planned LTM*   | *about 2017-08* |                 | *n+4*       |            |
-| *4.0*    | *Planned LTM*   | *about 2017-11* |                 |             |            |
+| *4.0*    | *Planned STM*   | *about 2017-11* |                 |             |            |


### PR DESCRIPTION
In the community meeting, it was discussed and decided that 4.0 would be an STM, as it is a feature rich and first release on the 4.0 release line.

Reflecting that in the web pages (and also updated github milestone accordingly)